### PR TITLE
refresh unpacked robot data if not caching

### DIFF
--- a/kscale/web/clients/robot_class.py
+++ b/kscale/web/clients/robot_class.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import logging
+import shutil
 import tarfile
 from pathlib import Path
 from typing import Any
@@ -171,8 +172,19 @@ class RobotClassClient(BaseClient):
 
         # Unpacks the file if requested.
         unpack_path = cache_path.parent / "robot"
-        unpack_path.mkdir(parents=True, exist_ok=True)
         unpacked_path_info = unpack_path / INFO_FILE_NAME
+
+        if not cache:
+            # If not using cache, remove the existing unpacked directory and file information.
+            if unpack_path.exists():
+                logger.info("Removing existing unpacked directory")
+                shutil.rmtree(unpack_path)
+
+            if unpacked_path_info.exists():
+                logger.info("Removing existing unpacked file information")
+                unpacked_path_info.unlink()
+
+        unpack_path.mkdir(parents=True, exist_ok=True)
 
         # If the file has already been unpacked, return the path.
         if unpacked_path_info.exists():

--- a/kscale/web/clients/robot_class.py
+++ b/kscale/web/clients/robot_class.py
@@ -175,14 +175,10 @@ class RobotClassClient(BaseClient):
         unpacked_path_info = unpack_path / INFO_FILE_NAME
 
         if not cache:
-            # If not using cache, remove the existing unpacked directory and file information.
+            # If not using cache, remove the existing unpacked directory.
             if unpack_path.exists():
                 logger.info("Removing existing unpacked directory")
                 shutil.rmtree(unpack_path)
-
-            if unpacked_path_info.exists():
-                logger.info("Removing existing unpacked file information")
-                unpacked_path_info.unlink()
 
         unpack_path.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
https://linear.app/k-scale/issue/K-287/re-extract-compressed-urdf-when-cache=false-in-the-kscale-cli

If users are modifying their `~/.kscale/[robot]` manually, the info hash check won't trigger the re-unpack

Validated locally through CLI